### PR TITLE
Remove `wordpress` exclusion pattern.

### DIFF
--- a/LifterLMS/ruleset.xml
+++ b/LifterLMS/ruleset.xml
@@ -14,7 +14,6 @@
 
     <exclude-pattern>tests/*</exclude-pattern>
     <exclude-pattern>tmp/*</exclude-pattern>
-    <exclude-pattern>wordpress/*</exclude-pattern>
     <exclude-pattern>vendor/*</exclude-pattern>
     <exclude-pattern>node_modules/*</exclude-pattern>
     <exclude-pattern>gulpfile.js/*</exclude-pattern>


### PR DESCRIPTION
## Description
The `wordpress` exclusion pattern is no longer needed and prevents checking of files that have `wordpress` in their path.
The current version of `lifterlms-test` installs WordPress into the `tmp/tests/wordpress` directory.

Fixes #3.

## How has this been tested?

Windows 10
PHP 7.4

```shell
vendor\bin\phpcs -v
```

#### Before
```
Registering sniffs in the LifterLMS Core standard... DONE (257 sniffs registered)
Creating file list... DONE (0 files in queue)
```

#### After
```
Registering sniffs in the LifterLMS Core standard... DONE (257 sniffs registered)
Creating file list... DONE (743 files in queue)
```

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [x] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

