### PR TITLE
Upgrade WPCS to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,9 @@ LifterLMS Coding Standards (LifterLMS-CS) is a project with rulesets for code st
 
 To include in a project require as a development dependency:
 
-`composer require lifterlms/lifterlms-cs:dev-master --dev`
+`composer require lifterlms/lifterlms-cs:dev-trunk --dev`
 
-Note that Composer won't run configuration scripts in this scenario and the root project needs to take care of it.
-
-After installing setup configurations:
-
-+ `./vendor/bin/phpcs --config-set installed_paths ../../../vendor/wp-coding-standards/wpcs,../../../vendor/lifterlms/lifterlms-cs,../../../vendor/phpcompatibility/php-compatibility,../../../vendor/phpcompatibility/phpcompatibility-paragonie,../../../vendor/phpcompatibility/phpcompatibility-wp`
-+ `./vendor/bin/phpcs --config-set default_standard LifterLMS"`
-
+If you are upgrading from the old version, be sure to remove any references to manually setting the `installed_paths`as they are now automatically set by Composer.
 
 ## Using PHPCS & PHPCBF
 
@@ -24,17 +18,12 @@ Access the PHPCS execultable via: `./vendor/bin/phpcs`
 Check for errors only: `./vendor/bin/phpcs --error-severity=1 --warning-severity=6`
 Fix errors via PHPCBF: `./vendor/bin/phpcbf`
 
-
 ## Predefined scripts
 
 The following scripts can be added to your `composer.json` file for easy access to thes scripts & to ensure configurations are automatically set during package installation and updates.
 
 ```json
 "scripts": {
-    "config-cs": [
-        "\"vendor/bin/phpcs\" --config-set installed_paths ../../../vendor/wp-coding-standards/wpcs,../../../vendor/lifterlms/lifterlms-cs,../../../vendor/phpcompatibility/php-compatibility,../../../vendor/phpcompatibility/phpcompatibility-paragonie,../../../vendor/phpcompatibility/phpcompatibility-wp",
-        "\"vendor/bin/phpcs\" --config-set default_standard LifterLMS"
-    ],
     "check-cs": [
         "\"vendor/bin/phpcs\" --colors"
     ],
@@ -43,12 +32,6 @@ The following scripts can be added to your `composer.json` file for easy access 
     ],
     "fix-cs": [
         "\"vendor/bin/phpcbf\""
-    ],
-    "post-install-cmd": [
-        "composer config-cs"
-    ],
-    "post-update-cmd": [
-        "composer config-cs"
     ]
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
     },
     "scripts": {
         "config-set" : [
-            "\"vendor/bin/phpcs\" --config-set installed_paths ../../..,../../../vendor/wp-coding-standards/wpcs,../../../vendor/phpcompatibility/php-compatibility,../../../vendor/phpcompatibility/phpcompatibility-wp",
             "\"vendor/bin/phpcs\" --config-set default_standard LifterLMS"
         ],
         "check-cs": [

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
         "check-cs": [
             "\"vendor/bin/phpcs\" --runtime-set testVersion 7.4-"
         ],
-        "post-install-cmd": "composer config-set",
-        "post-update-cmd": "composer config-set"
+        "post-install-cmd": "@config-set",
+        "post-update-cmd": "@config-set"
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "phpmd/phpmd": "^2.15.0"
     },
     "require-dev": {
-        "phpcompatibility/php-compatibility": "^9.0.0",
+        "phpcompatibility/php-compatibility": "^9.3.5",
         "roave/security-advisories": "dev-master"
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,15 @@
         "roave/security-advisories": "dev-master"
     },
     "scripts": {
+        "config-set" : [
+          "\"vendor/bin/phpcs\" --config-set installed_paths ../../../vendor/wp-coding-standards/wpcs,../../../vendor/lifterlms/lifterlms-cs,../../../vendor/phpcompatibility/php-compatibility,../../../vendor/phpcompatibility/phpcompatibility-paragonie,../../../vendor/phpcompatibility/phpcompatibility-wp,../../../vendor/phpcsstandards/phpcsutils,../../../vendor/phpcsstandards/phpcsextra",
+          "\"vendor/bin/phpcs\" --config-set default_standard LifterLMS"
+        ],
         "check-cs": [
             "\"vendor/bin/phpcs\" --runtime-set testVersion 7.4-"
-        ]
+        ],
+        "post-install-cmd": "composer config-set",
+        "post-update-cmd": "composer config-set"
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "require": {
         "php": ">=7.4",
         "wp-coding-standards/wpcs": "^3.0.0",
-        "phpcsstandards/phpcsutils": "^1.0"
+        "phpcsstandards/phpcsutils": "^1.0",
+        "phpcompatibility/phpcompatibility-wp": "^2.1"
     },
     "require-dev": {
         "roave/security-advisories": "dev-master"

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,7 @@
     ],
     "require": {
         "php": ">=7.4",
-        "squizlabs/php_codesniffer": "^3.9.0",
-        "wp-coding-standards/wpcs": "^3.0.1",
+        "wp-coding-standards/wpcs": "^3.0.0",
         "phpcompatibility/phpcompatibility-wp": "^2.1.4",
         "phpmd/phpmd": "^2.15.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,9 @@
     },
     "scripts": {
         "config-set" : [
-            "\"vendor/bin/phpcs\" --config-set default_standard LifterLMS"
         ],
         "check-cs": [
-            "\"vendor/bin/phpcs\" --runtime-set testVersion 5.6-"
+            "\"vendor/bin/phpcs\" --runtime-set testVersion 7.4-"
         ],
         "post-install-cmd": "composer config-set",
         "post-update-cmd": "composer config-set"

--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,9 @@
         "roave/security-advisories": "dev-master"
     },
     "scripts": {
-        "config-set" : [
-        ],
         "check-cs": [
             "\"vendor/bin/phpcs\" --runtime-set testVersion 7.4-"
-        ],
-        "post-install-cmd": "composer config-set",
-        "post-update-cmd": "composer config-set"
+        ]
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
     "require": {
         "php": ">=7.4",
         "wp-coding-standards/wpcs": "^3.0.0",
-        "phpcsstandards/phpcsutils": "^1.0",
         "phpcompatibility/phpcompatibility-wp": "^2.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     ],
     "require": {
         "php": ">=7.4",
-        "wp-coding-standards/wpcs": "^3.0.0"
+        "wp-coding-standards/wpcs": "^3.0.0",
+        "phpcsstandards/phpcsutils": "^1.0"
     },
     "require-dev": {
         "roave/security-advisories": "dev-master"

--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,11 @@
         }
     ],
     "require": {
-        "php": ">=5.6",
-        "squizlabs/php_codesniffer": "^3.3.2",
-        "wp-coding-standards/wpcs": "^2.1.1",
-        "phpcompatibility/phpcompatibility-wp": "^2.0.0",
-        "phpmd/phpmd": "^2.6.0"
+        "php": ">=7.4",
+        "squizlabs/php_codesniffer": "^3.9.0",
+        "wp-coding-standards/wpcs": "^3.0.1",
+        "phpcompatibility/phpcompatibility-wp": "^2.1.4",
+        "phpmd/phpmd": "^2.15.0"
     },
     "require-dev": {
         "phpcompatibility/php-compatibility": "^9.0.0",
@@ -30,5 +30,10 @@
         ],
         "post-install-cmd": "composer config-set",
         "post-update-cmd": "composer config-set"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
     },
     "scripts": {
         "config-set" : [
-          "\"vendor/bin/phpcs\" --config-set installed_paths ../../../vendor/wp-coding-standards/wpcs,../../../vendor/lifterlms/lifterlms-cs,../../../vendor/phpcompatibility/php-compatibility,../../../vendor/phpcompatibility/phpcompatibility-paragonie,../../../vendor/phpcompatibility/phpcompatibility-wp,../../../vendor/phpcsstandards/phpcsutils,../../../vendor/phpcsstandards/phpcsextra",
           "\"vendor/bin/phpcs\" --config-set default_standard LifterLMS"
         ],
         "check-cs": [

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,9 @@
     ],
     "require": {
         "php": ">=7.4",
-        "wp-coding-standards/wpcs": "^3.0.0",
-        "phpcompatibility/phpcompatibility-wp": "^2.1.4",
-        "phpmd/phpmd": "^2.15.0"
+        "wp-coding-standards/wpcs": "^3.0.0"
     },
     "require-dev": {
-        "phpcompatibility/php-compatibility": "^9.3.5",
         "roave/security-advisories": "dev-master"
     },
     "scripts": {


### PR DESCRIPTION
## Description

Upgrading WPCS library to v3. This is going into `trunk` as the `next` branch appears to have rules for "modern" LifterLMS repos which only one or two follow currently.

## How has this been tested?
Manually.

## Types of changes
Repos no longer need to manually set the `installed_paths` as composer will take care of this.
